### PR TITLE
opentelemetry-instrumentation-langchain 0.49.6 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-langchain" %}
-{% set version = "0.47.2" %}
+{% set version = "0.49.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: f74e126490733702de7d1277c78113a3272c7ac4932f6436df64c6916040ecd0
+  sha256: 51dbaa023b57040b4105fab4a17ae08bbc4f85d8acbd421e4784ed3f56bf6bfe
 
 build:
   number: 0
@@ -21,12 +21,21 @@ requirements:
     - poetry-core
   run:
     - python
-    - opentelemetry-api >=1.28.0,<2.0.0
-    - opentelemetry-instrumentation >=0.50b0
-    - opentelemetry-semantic-conventions >=0.50b0
+    - opentelemetry-api >=1.38.0,<2.0.0
+    - opentelemetry-instrumentation >=0.59b0
+    - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
   run_constrained:
+    - opentelemetry-sdk >=1.38.0,<2.0.0
     - langchain >=0.3.15,<0.4.0
+    - langchain-community >=0.3.3,<0.4.0
+    - langchain-anthropic >=0.3.13,<0.4.0
+    - langchain-aws >=0.2.11,<0.3.0
+    - langchain-openai >=0.3.1,<0.4.0
+    - langchain-cohere >=0.3.1,<0.4.0
+    - langchain-huggingface >=0.1.2,<0.2.0
+    - langchainhub >=0.1.21,<0.2.0
+    - langgraph >=0.4,<0.5
 
 test:
   imports:


### PR DESCRIPTION
opentelemetry-instrumentation-langchain 0.49.6 

**Destination channel:** Defaults

### Links

- [PKG-11118]
- dev_url:        https://github.com/traceloop/openllmetry/tree/0.49.6
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-langchain-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-langchain/0.49.6
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-langchain/0.49.6

### Explanation of changes:

- new version number


[PKG-11118]: https://anaconda.atlassian.net/browse/PKG-11118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ