### PR TITLE
[PKG-13419] Update to 0.57.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-langchain" %}
-{% set version = "0.49.6" %}
+{% set version = "0.57.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,35 +7,24 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 51dbaa023b57040b4105fab4a17ae08bbc4f85d8acbd421e4784ed3f56bf6bfe
+  sha256: d2cd2f4e3f4c306fb6f2a7275e8acc69fc683809e95347d599b9faf746ac287c
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:
     - pip
     - python
-    - poetry-core
+    - hatchling
   run:
     - python
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
-  run_constrained:
-    - opentelemetry-sdk >=1.38.0,<2.0.0
-    - langchain >=0.3.15,<0.4.0
-    - langchain-community >=0.3.3,<0.4.0
-    - langchain-anthropic >=0.3.13,<0.4.0
-    - langchain-aws >=0.2.11,<0.3.0
-    - langchain-openai >=0.3.1,<0.4.0
-    - langchain-cohere >=0.3.1,<0.4.0
-    - langchain-huggingface >=0.1.2,<0.2.0
-    - langchainhub >=0.1.21,<0.2.0
-    - langgraph >=0.4,<0.5
+    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
 
 test:
   imports:
@@ -44,7 +33,7 @@ test:
     - pip check
   requires:
     - pip
-    - langchain >=0.3.15,<0.4.0
+    - langchain >=1.0.0,<2.0.0
 
 about:
   home: https://www.traceloop.com/openllmetry
@@ -60,4 +49,4 @@ extra:
   recipe-maintainers:
     - timkpaine
   skip-lints:
-    - invalid_url
+    - reachable_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,11 @@ requirements:
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
+  run_constrained:
+    - langchain >=1.0.0,<2.0.0
 
+
+# Skip tests because 'langchain_anthropic' is not in the main channel.
 test:
   imports:
     - opentelemetry.instrumentation.langchain


### PR DESCRIPTION
opentelemetry-instrumentation-langchain 0.57.0

**Destination channel:** {Snowflake | defaults}

### Links

- [PKG-13419]
- [Upstream repository](https://github.com/traceloop/openllmetry/tree/v0.57.0/packages/opentelemetry-instrumentation-langchain)

### Explanation of changes:

- Update build system to hatchling
- Remove run_constrained based on test dependencies.


[PKG-13419]: https://anaconda.atlassian.net/browse/PKG-13419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ